### PR TITLE
Pin pydantic to 1.x in environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - fastapi=0.116.1
   - uvicorn=0.35.0
   - sqlalchemy=2.0.43
-  - pydantic=2.11.7
+  - pydantic=1.10.*
   - pyyaml=6.0.2
   - pip
   - pip:


### PR DESCRIPTION
## Summary
- update the conda environment to pin pydantic to the 1.10 release line for compatibility with the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e13fca12b0832da2268b860e1e13ce