### PR TITLE
Ensure controller defaults to auto mode on startup

### DIFF
--- a/backend/core/controller.py
+++ b/backend/core/controller.py
@@ -78,7 +78,15 @@ class Controller:
         with SessionLocal() as s:
             # runtime mode
             kv = s.get(RuntimeState, "mode")
-            if kv: self.mode = kv.value
+            if kv:
+                stored_mode = str(kv.value).strip().lower()
+                if stored_mode == "auto":
+                    self.mode = "auto"
+                else:
+                    # Tryb ręczny nie powinien być stanem startowym – po restarcie
+                    # zawsze wracamy do trybu automatycznego i aktualizujemy wpis.
+                    self.mode = "auto"
+                    kv.value = "auto"
             # vent states
             for v in self.vents.values():
                 vs = s.get(VentState, v.id)


### PR DESCRIPTION
## Summary
- force the controller to reset runtime mode to automatic when loading state so manual mode does not persist after restart

## Testing
- pytest tests/test_loop_delays.py

------
https://chatgpt.com/codex/tasks/task_b_68e149ef0a6c832d9c4bbe47f4e34eea